### PR TITLE
Fix for Subtitles moving to new dialog

### DIFF
--- a/1080i/DialogFullScreenInfo.xml
+++ b/1080i/DialogFullScreenInfo.xml
@@ -8,7 +8,7 @@
             <animation effect="slide" time="400" start="0,-375" end="0,0" easing="inout" tween="cubic">Visible</animation>
             <animation effect="slide" time="400" start="0,0" end="0,-375" easing="inout" tween="cubic">WindowClose</animation>
             <animation effect="slide" time="400" start="0,0" end="0,-375" easing="inout" tween="cubic">Hidden</animation>
-            <visible>![Skin.HasSetting(novideofurniture) | Window.IsActive(SubtitleSearch) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
+            <visible>![Skin.HasSetting(novideofurniture) | Window.IsActive(osdsubtitlesettings) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
             <control type="image">
                 <left>0</left>
                 <top>0</top>
@@ -101,7 +101,7 @@
             <animation effect="slide" time="400" start="0,1200" end="0,0" easing="out" tween="cubic">Visible</animation>
             <animation effect="slide" time="400" start="0,0" end="0,1200" easing="in" tween="cubic">WindowClose</animation>
             <animation effect="slide" time="400" start="0,0" end="0,1200" easing="in" tween="cubic">Hidden</animation>
-            <visible>![Window.IsActive(SubtitleSearch) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
+            <visible>![Window.IsActive(osdsubtitlesettings) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
             <control type="image">
                 <left>0</left>
                 <top>825</top>
@@ -220,7 +220,7 @@
             <animation effect="slide" time="400" start="0,0" end="0,1200" easing="in" tween="cubic">Hidden</animation>
             <animation effect="slide" start="0,0" end="0,-38" time="300" tween="cubic" easing="out" condition="Player.Forwarding | Player.Rewinding">Conditional</animation>
             <animation effect="slide" start="0,0" end="0,-100" time="400" tween="cubic" easing="inout" condition="Window.IsActive(videoosd)">Conditional</animation>
-            <visible>![Window.IsActive(SubtitleSearch) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
+            <visible>![Window.IsActive(osdsubtitlesettings) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
             <visible>!Skin.HasSetting(pvrdialoginfo) | !VideoPlayer.Content(LiveTV)</visible>
             <control type="image">
                 <!-- Barra de flags -->
@@ -493,7 +493,7 @@
             <animation effect="slide" time="400" start="0,0" end="0,1200" easing="in" tween="cubic">Hidden</animation>
             <animation effect="slide" start="0,0" end="0,-38" time="300" tween="cubic" easing="out" condition="Player.Forwarding | Player.Rewinding">Conditional</animation>
             <animation effect="slide" start="0,0" end="0,-100" time="400" tween="cubic" easing="inout" condition="Window.IsActive(videoosd)">Conditional</animation>
-            <visible>![Window.IsActive(SubtitleSearch) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
+            <visible>![Window.IsActive(osdsubtitlesettings) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
             <visible>Skin.HasSetting(pvrdialoginfo) + VideoPlayer.Content(LiveTV)</visible>
             <control type="image">
                 <left>0</left>
@@ -896,7 +896,7 @@
             <animation effect="slide" time="400" start="0,0" end="0,1200" easing="in" tween="cubic">Hidden</animation>
             <animation effect="slide" start="0,0" end="0,-38" time="300" tween="cubic" easing="out" condition="Player.Forwarding | Player.Rewinding">Conditional</animation>
             <animation effect="slide" start="0,0" end="0,-100" time="400" tween="cubic" easing="inout" condition="Window.IsActive(videoosd)">Conditional</animation>
-            <visible>![Window.IsActive(SubtitleSearch) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
+            <visible>![Window.IsActive(osdsubtitlesettings) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
             <visible>Skin.HasSetting(pvrdialoginfo) + VideoPlayer.Content(LiveTV)</visible>
             <control type="image">
                 <include>Animation_CDart</include>
@@ -1021,7 +1021,7 @@
             <font>Font_100</font>
             <label>31737</label>
             <textcolor>80FFFAF0</textcolor>
-            <visible>Player.Paused + ![Skin.HasSetting(nopausedlabel) | Window.IsActive(SubtitleSearch) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
+            <visible>Player.Paused + ![Skin.HasSetting(nopausedlabel) | Window.IsActive(osdsubtitlesettings) | Window.IsActive(pvrchannelguide) | Window.IsActive(pvrosdchannels) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]</visible>
             <animation type="Visible">
                 <effect type="slide" start="0,-900" end="0,0" time="600" tween="cubic" easing="out" />
                 <effect type="fade" start="0" end="100" time="600" />

--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -2,7 +2,7 @@
 <window>
     <!-- Aeon MQ 6 -->
     <defaultcontrol>23</defaultcontrol>
-    <visible>Window.IsActive(fullscreenvideo) + ![Window.IsActive(videoosd) | Window.IsActive(fullscreeninfo) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings) | Window.IsActive(SubtitleSearch)] + [Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding]</visible>
+    <visible>Window.IsActive(fullscreenvideo) + ![Window.IsActive(videoosd) | Window.IsActive(fullscreeninfo) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings) | Window.IsActive(osdsubtitlesettings)] + [Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding]</visible>
     <controls>
         <control type="group">
             <animation effect="slide" time="400" start="0,-375" end="0,0" easing="inout" tween="cubic">WindowOpen</animation>

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -11,7 +11,7 @@
             <animation effect="slide" time="400" start="0,-188" end="0,0" easing="out" tween="cubic">Visible</animation>
             <animation effect="slide" time="400" start="0,0" end="0,-188" easing="in" tween="cubic">WindowClose</animation>
             <animation effect="slide" time="400" start="0,0" end="0,-188" easing="in" tween="cubic">Hidden</animation>
-            <visible>![Window.IsVisible(seekbar) | Window.IsVisible(osdvideosettings) | Window.IsVisible(osdaudiosettings) | Window.IsActive(fullscreeninfo) | Window.IsActive(2901) | Skin.HasSetting(customosd)]</visible>
+            <visible>![Window.IsVisible(seekbar) | Window.IsVisible(osdvideosettings) | Window.IsVisible(osdaudiosettings) | Window.IsVisible(osdsubtitlesettings) | Window.IsActive(fullscreeninfo) | Window.IsActive(2901) | Skin.HasSetting(customosd)]</visible>
             <control type="image">
                 <left>0</left>
                 <top>0</top>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -56,7 +56,7 @@
             <animation effect="slide" time="400" start="0,-375" end="0,0" easing="out" tween="cubic">Visible</animation>
             <animation effect="slide" time="400" start="0,0" end="0,-375" easing="in" tween="cubic">WindowClose</animation>
             <animation effect="slide" time="400" start="0,0" end="0,-375" easing="in" tween="cubic">Hidden</animation>
-            <visible>![Window.IsVisible(osdvideosettings) | Window.IsVisible(osdaudiosettings) | Window.IsVisible(videobookmarks) | Window.IsActive(fullscreeninfo) | Skin.HasSetting(novideofurnituretemp) | Skin.HasSetting(customosd)]</visible>
+            <visible>![Window.IsVisible(osdvideosettings) | Window.IsVisible(osdaudiosettings) | Window.IsVisible(osdsubtitlesettings) | Window.IsVisible(videobookmarks) | Window.IsActive(fullscreeninfo) | Skin.HasSetting(novideofurnituretemp) | Skin.HasSetting(customosd)]</visible>
             <control type="image">
                 <left>0</left>
                 <top>0</top>
@@ -105,7 +105,7 @@
             <animation effect="slide" time="400" start="0,300" end="0,0" easing="out" tween="cubic">Visible</animation>
             <animation effect="slide" time="400" start="0,0" end="0,300" easing="in" tween="cubic">WindowClose</animation>
             <animation effect="slide" time="400" start="0,0" end="0,300" easing="in" tween="cubic">Hidden</animation>
-            <visible>![Window.IsVisible(osdvideosettings) | Window.IsVisible(osdaudiosettings) | Window.IsVisible(videobookmarks) | Window.IsVisible(sliderdialog) | Skin.HasSetting(novideofurnituretemp)]</visible>
+            <visible>![Window.IsVisible(osdvideosettings) | Window.IsVisible(osdaudiosettings) | Window.IsVisible(osdsubtitlesettings) | Window.IsVisible(videobookmarks) | Window.IsVisible(sliderdialog) | Skin.HasSetting(novideofurnituretemp)]</visible>
             <!-- Seek Widget -->
             <control type="group">
                 <left>-750</left>

--- a/1080i/includes.xml
+++ b/1080i/includes.xml
@@ -2957,8 +2957,8 @@
 				<label></label>
 				<property name="condition">$INFO[skin.string(osd_video_subtitle),disable)]</property>
 				<icon>osd_menu_sub.png</icon>
-				<onclick condition="!Skin.HasSetting(customosd)">Dialog.Close(VideoOSD)</onclick>
-				<onclick condition="!Skin.HasSetting(customosd)">ActivateWindow(SubtitleSearch)</onclick>
+				<!--<onclick condition="!Skin.HasSetting(customosd)">Dialog.Close(VideoOSD)</onclick>-->
+				<onclick condition="!Skin.HasSetting(customosd)">ActivateWindow(osdsubtitlesettings)</onclick>
 				<onclick condition="Skin.HasSetting(customosd) + !String.Contains(skin.string(osd_video_subtitle),disable)">Skin.SetString(osd_video_subtitle,disable)</onclick>
 				<onclick condition="Skin.HasSetting(customosd) + String.Contains(skin.string(osd_video_subtitle),disable)">Skin.Reset(osd_video_subtitle,disable)</onclick>
 				<visible>[!String.Contains(skin.string(osd_video_subtitle),disable) | Skin.HasSetting(customosd)] + !VideoPlayer.Content(LiveTV)</visible>


### PR DESCRIPTION
Fix for Subtitles moving to new dialog.

I've never written or modified a Kodi skin before, so this might be a total hack job, but it seems to at least get the job done.